### PR TITLE
JSON output

### DIFF
--- a/packages/cli/src/commands/heap/HeapAnalysisCommand.ts
+++ b/packages/cli/src/commands/heap/HeapAnalysisCommand.ts
@@ -20,6 +20,7 @@ import InitDirectoryCommand from '../InitDirectoryCommand';
 import HeapAnalysisPluginOption from '../../options/heap/HeapAnalysisPluginOption';
 import {ParsedArgs} from 'minimist';
 import HeapParserDictFastStoreSizeOption from '../../options/heap/HeapParserDictFastStoreSizeOption';
+import AnalysisOutputOption from '../../options/heap/AnalysisOutputOption';
 
 export default class RunHeapAnalysisCommand extends BaseCommand {
   getCommandName(): string {
@@ -42,6 +43,7 @@ export default class RunHeapAnalysisCommand extends BaseCommand {
     return [
       new HeapAnalysisPluginOption(),
       new HeapParserDictFastStoreSizeOption(),
+      new AnalysisOutputOption()
     ];
   }
 

--- a/packages/cli/src/options/heap/AnalysisOutputOption.ts
+++ b/packages/cli/src/options/heap/AnalysisOutputOption.ts
@@ -34,7 +34,7 @@ export default class AnalysisOutputOption extends BaseOption {
   ): Promise<void> {
     const name = this.getOptionName();
     config.outputFormat = AnalysisOutputOption.parseOutputFormat(args[name]);
-    if (config.outputFormat == OutputFormat.Json){
+    if (config.outputFormat === OutputFormat.Json){
       config.isContinuousTest = true;
     }
   }

--- a/packages/cli/src/options/heap/AnalysisOutputOption.ts
+++ b/packages/cli/src/options/heap/AnalysisOutputOption.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @oncall web_perf_infra
+ */
+
+import type { ParsedArgs } from 'minimist';
+import { AnyRecord, MemLabConfig, OutputFormat, utils } from '@memlab/core';
+import { BaseOption } from '@memlab/core';
+import optionConstants from '../lib/OptionConstant';
+
+export default class AnalysisOutputOption extends BaseOption {
+  getOptionName(): string {
+    return optionConstants.optionNames.OUTPUT;
+  }
+
+  getDescription(): string {
+    return (
+      'specify output format of the analysis (defaults to text)'
+    );
+  }
+
+  getExampleValues(): string[] {
+    return ['text', 'json'];
+  }
+
+  async parse(
+    config: MemLabConfig,
+    args: ParsedArgs,
+  ): Promise<void> {
+    const name = this.getOptionName();
+    config.outputFormat = AnalysisOutputOption.parseOutputFormat(args[name]);
+    if (config.outputFormat == OutputFormat.Json){
+      config.isContinuousTest = true;
+    }
+  }
+
+  private static parseOutputFormat(s: string): OutputFormat {
+    switch (s.toLowerCase()) {
+      case "text":
+        return OutputFormat.Text;
+      case "json":
+        return OutputFormat.Json;
+      default:
+        utils.haltOrThrow("Invalid output format");
+        return OutputFormat.Text;
+    }
+  }
+}

--- a/packages/cli/src/options/lib/OptionConstant.ts
+++ b/packages/cli/src/options/lib/OptionConstant.ts
@@ -66,6 +66,7 @@ const optionNames = {
   WORK_DIR: 'work-dir',
   WORKER_TITLE: 'worker',
   DEBUG: 'debug',
+  OUTPUT: 'output'
 };
 
 const optionShortcuts = {

--- a/packages/core/src/lib/Config.ts
+++ b/packages/core/src/lib/Config.ts
@@ -96,6 +96,7 @@ export type MuteConfig = {
   muteHighLevel?: boolean;
   muteMidLevel?: boolean;
   muteLowLevel?: boolean;
+  muteOutput?: boolean;
 };
 
 /** @internal */

--- a/packages/core/src/lib/Config.ts
+++ b/packages/core/src/lib/Config.ts
@@ -72,6 +72,12 @@ export enum TraceObjectMode {
 }
 
 /** @internal */
+export enum OutputFormat {
+  Text = 1,
+  Json = 2,
+}
+
+/** @internal */
 export enum ErrorHandling {
   Halt = 1,
   Throw = 2,
@@ -260,6 +266,7 @@ export class MemLabConfig {
   skipBrowserCloseWait: boolean;
   simplifyCodeSerialization: boolean;
   heapParserDictFastStoreSize: number;
+  outputFormat: OutputFormat
 
   constructor(options: ConfigOption = {}) {
     // init properties, they can be configured manually

--- a/packages/core/src/lib/Console.ts
+++ b/packages/core/src/lib/Console.ts
@@ -190,8 +190,12 @@ class MemLabConsole {
         .replace(/\[\d{1,3}m/g, ''),
     );
     this.log.push(...lines);
+    this.tryFlush();
+  }
+
+  private tryFlush(): void {
     if (this.log.length > LOG_BUFFER_LENGTH) {
-      this.flushLog({sync: true});
+      this.flushLog({ sync: true });
     }
   }
 
@@ -323,8 +327,14 @@ class MemLabConsole {
     }
   }
 
-  public writeRaw(s: string): void {
-    process.stdout.write(s);
+  public writeOutput(output: string): void {
+    if (this.config.muteConfig?.muteOutput) {
+      return;
+    }
+
+    process.stdout.write(output);
+    this.log.push(output);
+    this.tryFlush();
   }
 
   public registerLogFile(logFile: string): void {

--- a/packages/core/src/lib/Console.ts
+++ b/packages/core/src/lib/Console.ts
@@ -15,7 +15,7 @@ import fs from 'fs';
 import path from 'path';
 import readline from 'readline';
 import stringWidth from 'string-width';
-import type {MemLabConfig} from './Config';
+import { OutputFormat, type MemLabConfig } from './Config';
 import {AnyValue, Nullable, Optional} from './Types';
 
 type Message = {
@@ -39,7 +39,6 @@ type Sections = {
   arr: Section[];
 };
 
-const stdout = process.stdout;
 const TABLE_MAX_WIDTH = 50;
 const LOG_BUFFER_LENGTH = 100;
 const prevLine = '\x1b[F';
@@ -149,6 +148,14 @@ class MemLabConsole {
     return inst;
   }
 
+  private get isTextOutput(): boolean {
+    return this.config.outputFormat === OutputFormat.Text;
+  }
+
+  private get outStream() {
+    return this.isTextOutput ? process.stdout : process.stderr;
+  }
+
   private style(msg: string, name: keyof MemlabConsoleStyles): string {
     if (Object.prototype.hasOwnProperty.call(this.styles, name)) {
       return this.styles[name](msg);
@@ -243,7 +250,7 @@ class MemLabConsole {
       return;
     }
     if (!this.config.muteConsole) {
-      stdout.write(eraseLine);
+      this.outStream.write(eraseLine);
     }
     const msg = section.msgs.pop();
 
@@ -254,11 +261,11 @@ class MemLabConsole {
     const lines = msg.lines;
     while (lines.length > 0) {
       const line = lines.pop() ?? 0;
-      const width = stdout.columns;
+      const width = this.outStream.columns;
       let n = line === 0 ? 1 : Math.ceil(line / width);
       if (!this.config.muteConsole && !this.config.isTest) {
         while (n-- > 0) {
-          stdout.write(prevLine + eraseLine);
+          this.outStream.write(prevLine + eraseLine);
         }
       }
     }
@@ -306,8 +313,18 @@ class MemLabConsole {
       return;
     }
     if (this.config.isContinuousTest || !this.config.muteConsole) {
-      console.log(msg);
+      if (this.isTextOutput) {
+        console.log(msg);
+      }
+      else {
+        this.outStream.write(msg);
+        this.outStream.write('\n');
+      }
     }
+  }
+
+  public writeRaw(s: string): void {
+    process.stdout.write(s);
   }
 
   public registerLogFile(logFile: string): void {
@@ -498,7 +515,7 @@ class MemLabConsole {
   public waitForConsole(query: string): Promise<string> {
     const rl = readline.createInterface({
       input: process.stdin,
-      output: process.stdout,
+      output: this.outStream,
     });
     this.pushMsg(query);
     this.logMsg(query);
@@ -515,7 +532,7 @@ class MemLabConsole {
     total: number,
     options: {message?: string} = {},
   ): void {
-    let width = Math.floor(stdout.columns * 0.8);
+    let width = Math.floor(this.outStream.columns * 0.8);
     width = Math.min(width, 80);
     const messageMaxWidth = Math.floor(width * 0.3);
     let message = options.message || '';

--- a/packages/core/src/lib/Types.ts
+++ b/packages/core/src/lib/Types.ts
@@ -1593,6 +1593,15 @@ export interface IHeapLocation {
    */
   column: number;
   /**
+   * convert to a concise readable object that can be used for serialization
+   * (like calling `JSON.stringify(node, ...args)`).
+   *
+   * This API does not contain all the information
+   * captured by the hosting object.
+   */
+
+  getJSONifyableObject(): AnyRecord;
+  /**
    * convert to a concise readable string output
    * (like calling `JSON.stringify(node, ...args)`).
    *
@@ -1679,6 +1688,15 @@ export interface IHeapEdge extends IHeapEdgeBasic {
    * JS heap object where this reference starts
    */
   fromNode: IHeapNode;
+  /**
+   * convert to a concise readable object that can be used for serialization
+   * (like calling `JSON.stringify(node, ...args)`).
+   *
+   * This API does not contain all the information
+   * captured by the hosting object.
+   */
+
+  getJSONifyableObject(): AnyRecord;
   /**
    * convert to a concise readable string output
    * (like calling `JSON.stringify(node, ...args)`).
@@ -1904,6 +1922,15 @@ export interface IHeapNode extends IHeapNodeBasic {
    * inside the string node.
    */
   toStringNode(): Nullable<IHeapStringNode>;
+  /**
+   * convert to a concise readable object that can be used for serialization
+   * (like calling `JSON.stringify(node, ...args)`).
+   *
+   * This API does not contain all the information
+   * captured by the hosting object.
+   */
+
+  getJSONifyableObject(): AnyRecord;
   /**
    * convert to a concise readable string output
    * (like calling `JSON.stringify(node, ...args)`).

--- a/packages/core/src/lib/Types.ts
+++ b/packages/core/src/lib/Types.ts
@@ -1599,7 +1599,6 @@ export interface IHeapLocation {
    * This API does not contain all the information
    * captured by the hosting object.
    */
-
   getJSONifyableObject(): AnyRecord;
   /**
    * convert to a concise readable string output
@@ -1695,7 +1694,6 @@ export interface IHeapEdge extends IHeapEdgeBasic {
    * This API does not contain all the information
    * captured by the hosting object.
    */
-
   getJSONifyableObject(): AnyRecord;
   /**
    * convert to a concise readable string output

--- a/packages/core/src/trace-cluster/TraceElement.ts
+++ b/packages/core/src/trace-cluster/TraceElement.ts
@@ -9,6 +9,7 @@
  */
 
 import type {
+  AnyRecord,
   AnyValue,
   EdgeIterationCallback,
   IHeapEdge,
@@ -175,8 +176,8 @@ export class NodeRecord implements IHeapNode {
     throw new Error('NodeRecord.getReferrerNodes is not implemented');
   }
 
-  toJSONString(...args: Array<AnyValue>): string {
-    const rep = {
+  getJSONifyableObject(): AnyRecord {
+    return {
       id: this.id,
       kind: this.kind,
       name: this.name,
@@ -187,8 +188,10 @@ export class NodeRecord implements IHeapNode {
       incomingEdgeCount: this.numOfReferrers,
       contructorName: this.constructor.name,
     };
+  }
 
-    return JSON.stringify(rep, ...args);
+  toJSONString(...args: Array<AnyValue>): string {
+    return JSON.stringify(this.getJSONifyableObject(), ...args);
   }
 
   constructor(node: IHeapNode) {
@@ -233,16 +236,18 @@ export class EdgeRecord implements IHeapEdge {
     this.to_node = edge.to_node;
   }
 
-  toJSONString(...args: Array<AnyValue>): string {
-    const rep = {
+  getJSONifyableObject(): AnyRecord {
+    return {
       kind: this.kind,
       name_or_index: this.name_or_index,
       type: this.type,
       edgeIndex: this.edgeIndex,
       to_node: this.to_node,
     };
+  }
 
-    return JSON.stringify(rep, ...args);
+  toJSONString(...args: Array<AnyValue>): string {
+    return JSON.stringify(this.getJSONifyableObject(), ...args);
   }
 
   set snapshot(s: IHeapSnapshot) {

--- a/packages/heap-analysis/src/plugins/CollectionsHoldingStaleAnalysis.ts
+++ b/packages/heap-analysis/src/plugins/CollectionsHoldingStaleAnalysis.ts
@@ -101,7 +101,7 @@ export default class CollectionsHoldingStaleAnalysis extends BaseAnalysis {
   async process(options: HeapAnalysisOptions): Promise<void> {
     const snapshot = await pluginUtils.loadHeapSnapshot(options);
     const collectionsStat = this.getCollectionsWithStaleValues(snapshot);
-    if (config.outputFormat == OutputFormat.Json) {
+    if (config.outputFormat === OutputFormat.Json) {
       this.printJson(collectionsStat);
     }
     else {
@@ -173,7 +173,7 @@ export default class CollectionsHoldingStaleAnalysis extends BaseAnalysis {
         staleChildrenIds: stat.staleChildren.map(node => node.id),
       }));
 
-    info.writeRaw(JSON.stringify(output));
-    info.writeRaw('\n');
+    info.writeOutput(JSON.stringify(output));
+    info.writeOutput('\n');
   }
 }

--- a/packages/heap-analysis/src/plugins/CollectionsHoldingStaleAnalysis.ts
+++ b/packages/heap-analysis/src/plugins/CollectionsHoldingStaleAnalysis.ts
@@ -11,11 +11,13 @@
 import type {AnalyzeSnapshotResult, HeapAnalysisOptions} from '../PluginUtils';
 import type {IHeapSnapshot, IHeapNode} from '@memlab/core';
 
-import {info, utils, BaseOption} from '@memlab/core';
+import { info, utils, BaseOption, OutputFormat, config } from '@memlab/core';
 import BaseAnalysis from '../BaseAnalysis';
 import pluginUtils from '../PluginUtils';
 import chalk from 'chalk';
 import SnapshotFileOption from '../options/HeapAnalysisSnapshotFileOption';
+
+const MAX_COLLECTION_STAT_ITEMS = 20;
 
 type CollectionStat = {
   collection: IHeapNode;
@@ -99,7 +101,12 @@ export default class CollectionsHoldingStaleAnalysis extends BaseAnalysis {
   async process(options: HeapAnalysisOptions): Promise<void> {
     const snapshot = await pluginUtils.loadHeapSnapshot(options);
     const collectionsStat = this.getCollectionsWithStaleValues(snapshot);
-    this.print(collectionsStat);
+    if (config.outputFormat == OutputFormat.Json) {
+      this.printJson(collectionsStat);
+    }
+    else {
+      this.print(collectionsStat);
+    }
   }
 
   private getCollectionsWithStaleValues(
@@ -133,7 +140,7 @@ export default class CollectionsHoldingStaleAnalysis extends BaseAnalysis {
     }
 
     collections.sort((c1, c2) => c2.staleRetainedSize - c1.staleRetainedSize);
-    collections = collections.slice(0, 20);
+    collections = collections.slice(0, MAX_COLLECTION_STAT_ITEMS);
     for (const stat of collections) {
       const collection = stat.collection;
       const collectionSize = utils.getReadableBytes(collection.retainedSize);
@@ -153,5 +160,20 @@ export default class CollectionsHoldingStaleAnalysis extends BaseAnalysis {
       info.topLevel(`\n${dot} ${collectionDesc}:`);
       info.topLevel(`  ${childrenDesc}`);
     }
+  }
+
+  private printJson(collections: CollectionStat[]): void {
+    collections.sort((c1, c2) => c2.staleRetainedSize - c1.staleRetainedSize);
+    const output = collections.slice(0, MAX_COLLECTION_STAT_ITEMS)
+      .map(stat => ({
+        id: stat.collection.id,
+        size: utils.getReadableBytes(stat.collection.retainedSize),
+        childrenSize: stat.childrenSize,
+        staleChildrenSize: stat.staleChildren.length,
+        staleChildrenIds: stat.staleChildren.map(node => node.id),
+      }));
+
+    info.writeRaw(JSON.stringify(output));
+    info.writeRaw('\n');
   }
 }

--- a/packages/heap-analysis/src/plugins/ObjectContentAnalysis.ts
+++ b/packages/heap-analysis/src/plugins/ObjectContentAnalysis.ts
@@ -12,11 +12,12 @@ import type {IHeapEdge, IHeapNode, IHeapSnapshot} from '@memlab/core';
 import type {AnalyzeSnapshotResult, HeapAnalysisOptions} from '../PluginUtils';
 
 import chalk from 'chalk';
-import {BaseOption, config, utils, info} from '@memlab/core';
+import {BaseOption, config, utils, info, OutputFormat} from '@memlab/core';
 import NodeIdOption from '../options/HeapAnalysisNodeIdOption';
 import SnapshotFileOption from '../options/HeapAnalysisSnapshotFileOption';
 import BaseAnalysis from '../BaseAnalysis';
 import pluginUtils from '../PluginUtils';
+import PluginUtils from '../PluginUtils';
 
 class GlobalVariableAnalysis extends BaseAnalysis {
   getCommandName(): string {
@@ -43,7 +44,16 @@ class GlobalVariableAnalysis extends BaseAnalysis {
       info.lowLevel(`Specify an object by --node-id`);
       return;
     }
-    // print object info
+
+    if (config.outputFormat === OutputFormat.Json) {
+      PluginUtils.printNodeInTerminal(node);
+    }
+    else {
+      this.print(node, snapshot);
+    }
+  }
+
+  private print(node: IHeapNode, snapshot: IHeapSnapshot) {
     const id = chalk.grey(`@${node.id}`);
     info.topLevel(`Heap node (${node.type}) ${id}`);
     const name = chalk.grey(`${node.name}`);


### PR DESCRIPTION
PR changes:
* Adds `--output [text/json]` CLI option which sets the `outputFormat` config flag
* When output is set to JSON, it implies the `--sc` option and directs all logs to `stderr`. This allows to easily capture a clean JSON output using `memlab > result.json`.
* Adds `getJSONifyableObject` to the interfaces of nodes and edges
* Updates `printNodeListInTerminal` and `printReferencesInTerminal` to support JSON output
* Updates `CollectionsHoldingStaleAnalysis` to support JSON output

Open questions:
* Should all analyses support JSON output? I only added the ones I need at the moment.
* The output from `getJSONifyableObject` has inconsistent casing (e.g. snake `self_size` vs. camel `incomingEdgeCount`). Is it a breaking change to change this so it's all the same? Which case is preferrred?

Fixes #127