### PR TITLE
Added string type check on common logger function

### DIFF
--- a/packages/core/src/lib/Console.ts
+++ b/packages/core/src/lib/Console.ts
@@ -192,6 +192,9 @@ class MemLabConsole {
 
   private logMsg(msg: string): void {
     // remove control characters
+    if (typeof msg !== 'string') {
+      return;
+    }
     const lines = msg.split('\n').map(line =>
       line
         // eslint-disable-next-line no-control-regex


### PR DESCRIPTION
Type check on the console log. Causing the findLeak method to throw unhandled error, thus crashing the whole process.