### PR TITLE
Fix typo in E2E testing framework documentation

### DIFF
--- a/website/docs/guides/05-integrate-with-E2E-frameworks.md
+++ b/website/docs/guides/05-integrate-with-E2E-frameworks.md
@@ -12,7 +12,7 @@ framework (such as
 MemLab uses [Puppeteer](https://github.com/puppeteer/puppeteer)
 to interact with web browser and collect
 JavaScript heap snapshots for memory leak detection. If your organization
-is already using other E2E teesting framework such as Playwright or Cypress,
+is already using other E2E testing framework such as Playwright or Cypress,
 you would want to reuse the existing framework for E2E testing and pipe the
 intermediate results to MemLab for memory leak detection.
 


### PR DESCRIPTION
- Fixed a typo in the documentation, changing "teesting" to "testing" in the E2E frameworks integration guide.