### PR TITLE
fix(core): don't double-count representative trace in ML clustering

### DIFF
--- a/packages/core/src/__tests__/trace-cluster/MLTraceSimilarityStrategy.test.ts
+++ b/packages/core/src/__tests__/trace-cluster/MLTraceSimilarityStrategy.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @oncall memory_lab
+ */
+
+import type {LeakTrace} from '../../lib/Types';
+import MLTraceSimilarityStrategy from '../../trace-cluster/strategies/MLTraceSimilarityStrategy';
+
+function getTotalTraceCount(clusters: LeakTrace[][]): number {
+  return clusters.reduce((sum, cluster) => sum + cluster.length, 0);
+}
+
+test('diffTraces includes each trace in a cluster exactly once', () => {
+  const strategy = new MLTraceSimilarityStrategy();
+  const trace: LeakTrace = [
+    {kind: 'node', id: 1, name: 'LeakedObject', type: 'object'},
+    {kind: 'edge', name_or_index: 'next', type: 'property'},
+  ];
+
+  // a single trace still forms one cluster, and the representative trace
+  // must not be duplicated inside it
+  const single = strategy.diffTraces([trace]);
+  expect(getTotalTraceCount(single.allClusters)).toBe(1);
+
+  // identical traces are clustered together; each trace should appear in
+  // the result exactly once
+  const traces = [trace, [...trace], [...trace]];
+  const result = strategy.diffTraces(traces);
+  expect(getTotalTraceCount(result.allClusters)).toBe(traces.length);
+});

--- a/packages/core/src/trace-cluster/strategies/MLTraceSimilarityStrategy.ts
+++ b/packages/core/src/trace-cluster/strategies/MLTraceSimilarityStrategy.ts
@@ -31,7 +31,10 @@ export default class MLTraceSimilarityStrategy implements IClusterStrategy {
       const repTrace = newLeakTraces[traceIdx];
       const trace = newLeakTraces[i];
       if (!map.has(repTrace)) {
-        map.set(repTrace, [repTrace]);
+        // initialize the cluster with an empty trace list; every trace
+        // (including the representative trace itself) is added below exactly
+        // once, otherwise the representative would be counted twice
+        map.set(repTrace, []);
       }
       // to please linter
       map.get(repTrace)?.push(trace);


### PR DESCRIPTION
## Problem

When `--ml-clustering` is enabled, `MLTraceSimilarityStrategy.diffTraces` double-counts the representative trace of every cluster:

```ts
const map = new Map<LeakTrace, LeakTrace[]>();
for (let i = 0; i < result.length; i++) {
  const traceIdx = result[i];
  const repTrace = newLeakTraces[traceIdx];
  const trace = newLeakTraces[i];
  if (!map.has(repTrace)) {
    map.set(repTrace, [repTrace]); // seeds the cluster with the rep
  }
  map.get(repTrace)?.push(trace);  // pushes the rep AGAIN when i === traceIdx
}
```

The HAC union-find labels in `result` point every trace at the largest index in its cluster, and exactly one trace per cluster satisfies `result[i] === i` (the representative). For that one trace, `repTrace === trace`, so it is inserted by the seed and pushed again by the loop — every cluster ends up containing its representative twice. This propagates to `TraceCluster.count`, so `--Similar leaks in this run: N--` and `num_duplicates` are inflated by 1 per cluster, and even a single leaked object reports `Similar leaks: 2`.

## Fix

Initialize each cluster list empty and let the loop add every trace exactly once.

## Test

Added `packages/core/src/__tests__/trace-cluster/MLTraceSimilarityStrategy.test.ts`, which fails before the fix (single trace → 2) and passes after (each trace counted once). All core and heap-analysis tests pass.