### PR TITLE
Remove underline from README badges by removing whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,9 @@
 </h1>
 
 <p align="center">
-  <a href="https://github.com/facebook/memlab/blob/master/LICENSE">
-    <img alt="Licensed under the MIT License" src="https://img.shields.io/badge/License-MIT-blue.svg"/>
-  </a>
-  <a href="https://github.com/facebook/memlab/blob/main/CONTRIBUTING.md">
-    <img alt="PR's Welcome" src="https://img.shields.io/badge/PRs%20-welcome-brightgreen.svg"/>
-  </a>
-  <a href="https://www.npmjs.com/package/memlab?activeTab=readme">
-    <img alt="npm version" src="https://img.shields.io/npm/v/memlab.svg?style=flat"/>
-  </a>
+  <a href="https://github.com/facebook/memlab/blob/master/LICENSE"><img alt="Licensed under the MIT License" src="https://img.shields.io/badge/License-MIT-blue.svg"/></a>
+  <a href="https://github.com/facebook/memlab/blob/main/CONTRIBUTING.md"><img alt="PR's Welcome" src="https://img.shields.io/badge/PRs%20-welcome-brightgreen.svg"/></a>
+  <a href="https://www.npmjs.com/package/memlab?activeTab=readme"><img alt="npm version" src="https://img.shields.io/npm/v/memlab.svg?style=flat"/></a>
 </p>
 
 memlab is an end-to-end testing and analysis framework for identifying


### PR DESCRIPTION
before:
<img width="267" height="29" alt="image" src="https://github.com/user-attachments/assets/4ce6d03a-01ab-42ce-8599-3d982f89f7c0" />

after:

<img width="268" height="26" alt="image" src="https://github.com/user-attachments/assets/a8aae682-e547-4c8f-a8da-8d942ba546cd" />
